### PR TITLE
Milan Goranović - Update 1 

### DIFF
--- a/WebVella.Erp.ConsoleApp/Program.cs
+++ b/WebVella.Erp.ConsoleApp/Program.cs
@@ -10,7 +10,7 @@ using WebVella.Erp.Hooks;
 
 namespace WebVella.Erp.ConsoleApp
 {
-	class Program
+	static class Program
 	{
 		static void Main()
 		{


### PR DESCRIPTION
 The 'static' keyword was added to the class declaration.
WebVella.Erp.ConsoleApp/Program.cs - L13
Rule ID: S1118